### PR TITLE
Reorganize to clearly show the differences between Eng levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,171 +7,133 @@ These are the evaluation criteria we use for performance evaluation and leveling
 3. Collaboration & Communication
 4. Community & Citizenship
 
-Jump to competencies for a particular level:
-
-* [Software Engineering Intern](#software-engineering-intern)
-* [Software Engineer](#software-engineer)
-* [Software Engineer 2](#software-engineer-2)
-* [Senior Software Engineer](#senior-software-engineer)
-* [Staff Software Engineer](#staff-software-engineer)
-
-
-## Software Engineering Intern
+Within each of these categories, we have further broken down the list into competencies that are applicable at every level and competencies that are only applicable at particular Software Engineer levels. Thes are designed to be cumulative; skills that are expected at Software Engineer 2, for example, are also expected at Senior Software Engineer & beyond. 
 
 ### Software Engineering & Design
 
-- You write efficient and readable code, you ask for help evaluating pros and cons of various approaches, and your code is easy to maintain.
+#### All Levels
+- You write efficient and readable code.
+- You evaluate pros and cons of various approaches, asking for help when needed.
+- Your code is easy to maintain.
 - You are learning and applying our standards around design, testing, error handling, monitoring, alerting, and documentation.
 - You proactively maintain, debug, and fix problems in your code.
 - You seek out and learn industry best practices and standards.
-- You work with your manager and senior engineers to write technical proposals and solicit feedback from the team. You attend architecture review discussions.
+- You write high quality technical proposals and solicit feedback from the team. 
+- You attend architecture review discussions.
 
-### Execution & Results
+#### Software Engineer Intern
 
-- You effectively manage your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You ask for help breaking down large tasks into smaller tasks that are easier to complete.
-- You ask for help investigating existing components and services when approaching new projects and feature requests.
+- You ask for help in order to meet the above competencies.
 
-### Collaboration & Communication
+#### Software Engineer
 
-- You work collaboratively with your manager and senior engineers, gathering feedback on architecture and implementation decisions.
-- You are responsive to peer feedback on code reviews and learn from it.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You work with your manager and senior engineers to challenge assumptions and make sure you are solving the right problems.
+- You sometimes ask for help on meeting the above competencies, but can also meet them on your own.
 
-### Community & Citizenship
+#### Software Engineer 2
 
-- You do things to benefit your peers and community such as participating in meetings and providing constructive feedback on ideas and initiatives.
-
-## Software Engineer
-
-### Software Engineering & Design
-
-- You write efficient and readable code, you evaluate the pros and cons of various approaches, and write high quality technical proposals.
-- You are learning and applying our standards around design, testing, error handling, monitoring, alerting, and documentation.
-- You proactively maintain, debug, and fix problems in your code.
-- You seek out and learn industry best practices and standards.
-
-### Execution & Results
-- You effectively manage your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You are given a set of large tasks and are able to effectively break them down into smaller tasks, which are easier to complete.
-- You actively participate in your team’s on-call rotation.
-
-### Collaboration & Communication
-
-- You seek and provide feedback from engineers on the team in regards to design & technical decisions, technical proposals, and production readiness.
-- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from them.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You ask thoughtful questions and challenge assumptions to ensure you are solving the right problems.
-
-### Community & Citizenship
-
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs, and providing constructive comments.
-- You fix out of date code, tests, scripts and documentation.
-
-## Software Engineer 2
-
-### Software Engineering & Design
-
-- You write efficient and readable code, you evaluate the pros and cons of various approaches, and write high quality technical proposals.
-- You are applying our standards around design, testing, error handling, monitoring, alerting, and documentation.
-- You proactively maintain, debug, and fix problems in your code.
 - You take responsibility for delivery of your code including design, coding, testing, monitoring/alerts, deployment and rollout.
 - Your code handles interactions between multiple systems/components that span multiple diffs to address complex projects.
-- You seek out and learn industry best practices and standards, which you incorporate in your coding patterns, design & architecture
+- You incorporate industry best practices in your coding patterns, design & architecture.
 
-### Execution & Results
+#### Senior Software Engineer
 
-- You effectively manage your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You break down well defined requirements into milestones and larger tasks.
-- You actively participate in your teams on-call rotation.
-
-### Collaboration & Communication
-
-- You seek and provide feedback on your own design & technical proposals while encouraging other engineers on the team to follow the same best practices.
-- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from them.
-- You ask thoughtful questions and challenge assumptions to ensure you are solving the right problems.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You help other engineers on the end to end delivery of their code from design, code, tests, monitoring/alerts, deployment and rollout.
-
-### Community & Citizenship
-
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs and providing constructive comments.
-- You fix out of date code, tests, scripts, runbooks, and documentation.
-- You are interviewing trained and share the interview load for your team.
-
-## Senior Software Engineer
-
-### Software Engineering & Design
-
-- You have established a track record of writing efficient and readable code, you evaluate the pros and cons of various approaches, and write high quality technical documentation, that are easy to maintain for the next six months.
+- You have an established record of the above competencies over at least six months
 - You are applying and helping define our standards around design, testing, error handling, monitoring, alerting, and documentation.
-- You proactively maintain, debug, and fix problems in your code.
-- You have established a track record of handling the responsibility of delivery of your code including design, coding, testing, monitoring/alerts, deployment and rollout.
-- Your code handles interactions between multiple systems/components that span multiple diffs to address complex projects.
-- You have established a track record of seeking out and learning industry best practices and standards, which you incorporate in your coding patterns, design & architecture. You instill these best practices and standards into our engineering team.
+- You sometimes host architecture review discussions.
 
-### Execution & Results
-- You have established a track record of effectively managing your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You help create organization and structure around large projects & problems that aren’t well defined, thereby setting your team up to successfully deliver on initiatives.
-- You have established a track record of investigating and vetting the reuse of existing components and services when approaching new projects and feature requests.
-- You can orchestrate and coordinate projects & solve problems that span across multiple teams.
-- You actively participate in your teams on-call rotation and consistently help identify root causes of issues and help resolve them. You proactively communicate with your peers on incident status and create post-mortems when appropriate.
+#### Staff Software Engineer
 
-### Collaboration & Communication
-
-- You seek feedback on your own design & technical proposals while facilitating technical discussions on the team and making sure other engineers follow the same best practices.
-- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from it.
-- You ask thoughtful questions and challenge assumptions to ensure you and your team are solving the right problems.
-- You listen attentively to team members’ ideas and concerns, consider their viewpoints, and ask clarifying questions that elicit clearer responses.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You help other engineers on the end to end delivery of their code from design, code, tests, monitoring/alerts, deployment and rollout.
-- You start becoming a domain resource to engineers outside of your team and help them leverage the right solutions.
-
-### Community & Citizenship
-
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs and providing constructive comments.
-- You fix out of date code, tests, scripts, runbooks, and documentation.
-- You are interview-trained and share the interview load for your team.
-- You mentor members of your team and help them grow and develop.
-  
-## Staff Software Engineer
-
-### Software Engineering & Design
-
-- You have established a track record of writing efficient and readable code, you evaluate the pros and cons of various approaches, and write high quality technical proposals that are easy to maintain for the next six months.
-- You are applying and and consistently defining our standards around design, testing, error handling, monitoring, alerting, and documentation.
-- You proactively maintain, debug, and fix problems in your code.
-- You have established a track record of handling the responsibility of delivery of your code including design, coding, testing, monitoring/alerts, deployment and rollout.
-- Your code handles interactions between multiple systems/components that span multiple diffs to address complex projects.
-- You have established a track record of seeking out and learning industry best practices and standards, which you incorporate in your coding patterns, design & architecture. You instill these best practices and standards into our engineering team.
-- You have established a track record of writing high quality technical proposals, solicit feedback from the team, and host/attend architecture review discussions.
 - You have established a track record of enabling others to successfully deliver on and implement end-to-end technical proposals.
 
 ### Execution & Results
 
-- You have established a track record of effectively managing your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You have established a track record of helping create organization and structure around large projects & problems that aren’t well defined, thereby setting your team and other engineering teams up to successfully deliver on initiatives.
-- You have established a track record of investigating and vetting the reuse of existing components and services when approaching new projects and feature requests.
-  I.e. you have delivered projects and work that shows this in a repeatable fashion
-- You have established a track record of orchestrating and coordinating projects, solving problems, and delivering successful solutions that may span across multiple teams.
-- You actively participate in your teams on-call rotation.
+#### All Levels
+
+- You effectively manage your time and know when to ask for help to unblock yourself. 
+- When blocked, you are resourceful and take initiative in finding other tasks to complete.
+- You are able to effectively break down large tasks into smaller tasks that are easier to complete.
+- You investigate existing components and services when approaching new projects and feature requests.
+
+#### Software Engineer Intern
+
+- You ask for help in order to meet the above competencies.
+
+#### Software Engineer
+
+- You sometimes ask for help on meeting the above competencies, but can also meet them on your own.
+- You actively participate in your team’s on-call rotation.
+
+#### Software Engineer 2
+
+- You break down well defined requirements into milestones and larger tasks.
+
+#### Senior Software Engineer
+
+- You have an established track record of the above competencies
+- You help create organization and structure around large projects & problems that aren’t well defined, thereby setting your team up to successfully deliver on initiatives.
+- You can orchestrate and coordinate projects & solve problems that span across multiple teams.
+- You consistently help identify root causes of issues and help resolve them. 
+- You proactively communicate with your peers on incident status and create post-mortems when appropriate.
+
+
+#### Staff Software Engineer
+
+- You have an established track record of the above through delivered projects and work.
+
 
 ### Collaboration & Communication
 
-- You seek feedback on your own design & technical proposals while facilitating technical discussions on the team and making sure other engineers follow the same best practices.
-- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from it.
-- You ask thoughtful questions and challenge assumptions to ensure you and your team are solving the right problems.
+#### All Levels
+- You seek and provide feedback from engineers on the team in regards to design & technical decisions, technical proposals, and production readiness.
+- You work collaboratively with your manager and senior engineers, gathering feedback on architecture and implementation decisions.
+- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from them.
 - You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
+- You ask thoughtful questions and challenge assumptions to ensure you are solving the right problems.
+
+#### Software Engineer Intern
+- You work collaboratively with your manager and senior engineers in order to meet the above expectations.
+
+#### Software Engineer
+- You sometimes work collaboratively with your manager and senior engineers in order to meet the above expectations, but work independently in most cases.
+
+#### Software Engineer 2
+
+- You encourage other engineers on the team to follow the same best practices you bring to design & technical decisions.
 - You help other engineers on the end to end delivery of their code from design, code, tests, monitoring/alerts, deployment and rollout.
+
+#### Senior Software Engineer
+
+- You facilitate technical discussions on the team and making sure other engineers follow the same best practices.
+- You listen attentively to team members’ ideas and concerns, consider their viewpoints, and ask clarifying questions that elicit clearer responses.
+- You start becoming a domain resource to engineers outside of your team and help them leverage the right solutions.
+
+#### Staff Software Engineer
+
 - You are a domain resource to engineers outside of your team and help them leverage the right solutions.
 
 ### Community & Citizenship
 
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs and providing constructive comments.
-- You fix out of date code, tests, scripts, runbooks, and documentation.
+#### All Levels
+
+- You do things to benefit your peers and community such as participating in meetings and providing constructive feedback on ideas and initiatives.
+
+#### Software Engineer Intern
+*(Nothing additional)*
+
+#### Software Engineer
+
+- You fix out of date code, tests, scripts and documentation.
+
+#### Software Engineer 2
+
 - You are interviewing trained and share the interview load for your team.
-- You mentor members both within and outside of your team to help them grow and develop.
+
+#### Senior Software Engineer
+
+- You mentor members of your team and help them grow and develop.
+
+#### Staff Software Engineer
+
 - You introduce frameworks and abstractions that improve the efficiency of other engineers.
 
 ## FAQ


### PR DESCRIPTION
Addressing issue #11 
Previously, it was very difficult to understand the differentiators between various engineering levels, because shared competencies would get duplicated across the levels. 

Now, instead of having separate version of each level's competencies, the competency categories list out the differentiators between the levels.

Note: In order to accomplish the above, some rewording had to occur, especially in the differentiation of Senior v. Staff and Intern v. Software Engineer; please take extra care reviewing these changes to make sure the spirit of the competency is still accurately represented.