### PR TITLE
Added criteria for backend takehome as well

### DIFF
--- a/interviews/README.md
+++ b/interviews/README.md
@@ -1,0 +1,32 @@
+# Takehome Grading
+
+Hi!
+This is our grading rubric for takehome projects.
+Thanks for taking a look!
+
+These are the scores by which our engineering team evaluate backend takehome assignments.
+We _don't_ establish a hard minimum of score for any opening -- these scores are a general rubric, not a hard rule.
+
+## Rubrics
+
+- [Intern Backend Takehome](./frontend-takehome.md)
+- [Intern Frontend Takehome](./backend-takehome.md)
+
+## Why?
+
+We believe in openness and transparency in our engineering practices.
+There must be _some_ criteria by which we evaluate takehome submissions, and if candidates are meant to be taking them, we'd like them to be clear to everyone.
+
+We also welcome any feedback you have on these!
+
+## Takehome Assignment Specifications
+
+In our opinion, an ideal takehome assignment should:
+
+- Expect (and state) a maximum time spent as 2-3 hours
+- Explain clear, easy-to-understand instructions, including:
+  - Minimum requirements for a successful submission
+  - Areas of work we expect the candidate to focus on
+  - Areas of work we do not expect the candidate to focus on or tackle at all
+- Provide enough range of complexity for submissions to demonstrate excellence in implementation
+- Request a limited 'bonus'/'delighter' feature set, with multiple options suggested to match various skill sets

--- a/interviews/README.md
+++ b/interviews/README.md
@@ -1,11 +1,11 @@
 # Takehome Grading
 
 Hi!
-This is our grading rubric for takehome projects.
+These are our grading guidelines for takehome projects.
 Thanks for taking a look!
 
-These are the scores by which our engineering team evaluate backend takehome assignments.
-We _don't_ establish a hard minimum of score for any opening -- these scores are a general rubric, not a hard rule.
+These are the criteria our engineering team uses to evaluate takehome assignments.
+We don't set a minimum score for any opening, and although we take these criteria very seriously, we also reserve the right to use considerations beyond these rubrics in our decision making.
 
 ## Rubrics
 

--- a/interviews/README.md
+++ b/interviews/README.md
@@ -9,13 +9,15 @@ We don't set a minimum score for any opening, and although we take these criteri
 
 ## Rubrics
 
+Here are the specific grading rubrics we use to evaluate each of our takehome assignments:
+
 - [Intern Backend Takehome](./frontend-takehome.md)
 - [Intern Frontend Takehome](./backend-takehome.md)
 
 ## Why?
 
 We believe in openness and transparency in our engineering practices.
-There must be _some_ criteria by which we evaluate takehome submissions, and if candidates are meant to be taking them, we'd like them to be clear to everyone.
+There must be _some_ criteria by which we evaluate takehome submissions, and we'd like them to be clear to everyone.
 
 We also welcome any feedback you have on these!
 

--- a/interviews/backend-takehome.md
+++ b/interviews/backend-takehome.md
@@ -20,7 +20,7 @@ Code is generally well-organized and easy to understand.
 - 👎 2 - Not idiomatic for language chosen; difficult to understand and trace
 - 🛑 1 - Very difficult to understand; non-standard formatting; variable names confusing
 
-### Data structures and runtime
+### Data Structures and Organization
 
 Data structures are chosen appropriately for low complexity and low memory allocation.
 

--- a/interviews/backend-takehome.md
+++ b/interviews/backend-takehome.md
@@ -1,0 +1,43 @@
+# Backend Takehome Grading
+
+## Section Scores
+
+### Solution Completion
+
+All requirements are met as outlined by the assignment's requirements.
+
+- 💖 4 - Perfect
+- 👍 3 - One minor bug with flow using expected inputs, or a couple bugs with validation of corner cases
+- 👎 2 - Two or more missed requirements
+- 🛑 1 - Several requirements missed; compile errors that are not trivial to resolve
+
+### Code Quality
+
+Code is generally well-organized and easy to understand.
+
+- 💖 4 - Well-organized, DRY, easily readable, good variable/function names, would pass linter w/minimal issues
+- 👍 3 - Minor repetition in logic, a couple confusing variable/function names, minor formatting issues
+- 👎 2 - Not idiomatic for language chosen, difficult to understand and trace
+- 🛑 1 - Unable to understand, non-standard formatting, variable names difficult to follow
+
+### Data structures and runtime
+
+Data structures are chosen appropriately for low complexity and low memory allocation
+
+- 💖 4 - Appropriate data structures; efficient use of conditionals/loops; minimal array scanning; appropriate passing of parameters and return values
+- 👍 3 - Reasonable use of data structures; some opportunity for reduction of costly repeated operations; some inefficiency in usage of parameters and return values
+- 👎 2 - Excessive hardcoding of control flow and repetition of the same logic
+- 🛑 1 - Can enter unintended infinite loops; may not function properly; shows lack of understanding of data structures
+
+### Testing
+
+While unit tests are not required, some form of test that verifies that the code is working appropriately needs to exist
+
+- 💖 4 - Unit tests or script that tests various logic branches including edge cases; tests are granular and tied to specific functions
+- 👍 3 - Unit tests or script that tests main logic branches but not edge cases; tests not tied to specific functions but rather groups of them
+- 👎 2 - Unit tests/script are not repeatable
+- 🛑 1 - No unit tests or scripts
+
+### Bonus
+
+This category could be used as a tie-breaker for candidates that scored similarly in other categories. Please [review the challenge requirements for the bonus](https://github.com/Codecademy/internship-code-challenge/tree/master/backend#bonus)

--- a/interviews/backend-takehome.md
+++ b/interviews/backend-takehome.md
@@ -22,7 +22,7 @@ Code is generally well-organized and easy to understand.
 
 ### Data structures and runtime
 
-Data structures are chosen appropriately for low complexity and low memory allocation
+Data structures are chosen appropriately for low complexity and low memory allocation.
 
 - 💖 4 - Appropriate data structures; efficient use of conditionals/loops; minimal array scanning; appropriate passing of parameters and return values
 - 👍 3 - Reasonable use of data structures; some opportunity for reduction of costly repeated operations; some inefficiency in usage of parameters and return values
@@ -31,7 +31,7 @@ Data structures are chosen appropriately for low complexity and low memory alloc
 
 ### Testing
 
-While unit tests are not required, some form of test that verifies that the code is working appropriately needs to exist
+Unit tests verify the code is working appropriately.
 
 - 💖 4 - Unit tests or script that tests various logic branches including edge cases; tests are granular and tied to specific functions
 - 👍 3 - Unit tests or script that tests main logic branches but not edge cases; tests not tied to specific functions but rather groups of them

--- a/interviews/backend-takehome.md
+++ b/interviews/backend-takehome.md
@@ -6,8 +6,8 @@
 
 All requirements are met as outlined by the assignment's requirements.
 
-- 💖 4 - Perfect
-- 👍 3 - One minor bug with flow using expected inputs, or a couple bugs with validation of corner cases
+- 💖 4 - All stated requirements satisfied.
+- 👍 3 - One minor bug with flow using expected inputs or a couple of bugs around corner cases
 - 👎 2 - Two or more missed requirements
 - 🛑 1 - Several requirements missed; compile errors that are not trivial to resolve
 
@@ -15,10 +15,10 @@ All requirements are met as outlined by the assignment's requirements.
 
 Code is generally well-organized and easy to understand.
 
-- 💖 4 - Well-organized, DRY, easily readable, good variable/function names, would pass linter w/minimal issues
-- 👍 3 - Minor repetition in logic, a couple confusing variable/function names, minor formatting issues
+- 💖 4 - Well-organized, DRY, easily readable, good variable/function names, would pass linter with few issues
+- 👍 3 - Minor repetition in logic, a couple of confusing variable/function names, minor formatting issues
 - 👎 2 - Not idiomatic for language chosen, difficult to understand and trace
-- 🛑 1 - Unable to understand, non-standard formatting, variable names difficult to follow
+- 🛑 1 - Very difficult to understand, non-standard formatting, variable names confusing
 
 ### Data structures and runtime
 
@@ -33,11 +33,11 @@ Data structures are chosen appropriately for low complexity and low memory alloc
 
 Unit tests verify the code is working appropriately.
 
-- 💖 4 - Unit tests or script that tests various logic branches including edge cases; tests are granular and tied to specific functions
+- 💖 4 - Unit tests or script that tests all non-trivial logic branches, including edge cases; tests are granular and tied to specific functions
 - 👍 3 - Unit tests or script that tests main logic branches but not edge cases; tests not tied to specific functions but rather groups of them
 - 👎 2 - Unit tests/script are not repeatable
 - 🛑 1 - No unit tests or scripts
 
 ### Bonus
 
-This category could be used as a tie-breaker for candidates that scored similarly in other categories. Please [review the challenge requirements for the bonus](https://github.com/Codecademy/internship-code-challenge/tree/master/backend#bonus)
+This category may be used as a tie-breaker for candidates who score similarly in other categories. Please [review the challenge requirements for the bonus](https://github.com/Codecademy/internship-code-challenge/tree/master/backend#bonus)

--- a/interviews/backend-takehome.md
+++ b/interviews/backend-takehome.md
@@ -15,10 +15,10 @@ All requirements are met as outlined by the assignment's requirements.
 
 Code is generally well-organized and easy to understand.
 
-- 💖 4 - Well-organized, DRY, easily readable, good variable/function names, would pass linter with few issues
-- 👍 3 - Minor repetition in logic, a couple of confusing variable/function names, minor formatting issues
-- 👎 2 - Not idiomatic for language chosen, difficult to understand and trace
-- 🛑 1 - Very difficult to understand, non-standard formatting, variable names confusing
+- 💖 4 - Well-organized; DRY; easily readable; good variable/function names; would pass linter with few issues
+- 👍 3 - Minor repetition in logic; a couple of confusing variable/function names; minor formatting issues
+- 👎 2 - Not idiomatic for language chosen; difficult to understand and trace
+- 🛑 1 - Very difficult to understand; non-standard formatting; variable names confusing
 
 ### Data structures and runtime
 
@@ -33,7 +33,7 @@ Data structures are chosen appropriately for low complexity and low memory alloc
 
 Unit tests verify the code is working appropriately.
 
-- 💖 4 - Unit tests or script that tests all non-trivial logic branches, including edge cases; tests are granular and tied to specific functions
+- 💖 4 - Unit tests or script that tests all non-trivial logic branches; including edge cases; tests are granular and tied to specific functions
 - 👍 3 - Unit tests or script that tests main logic branches but not edge cases; tests not tied to specific functions but rather groups of them
 - 👎 2 - Unit tests/script are not repeatable
 - 🛑 1 - No unit tests or scripts

--- a/interviews/frontend-takehome.md
+++ b/interviews/frontend-takehome.md
@@ -17,7 +17,7 @@ Application can be used smoothly and without visible bugs.
 
 - 💖 4: Works smoothly and delightfully without any bugs
 - 👍 3: Works well with little to no buggy behavior on edge cases
-- 👎 2: Moderate bug or two on a major feature, or major bugs on edge cases
+- 👎 2: Moderate bug or two on a major feature; or major bugs on edge cases
 - 🛑 1: Significant buggy behavior
 
 ### Code Quality

--- a/interviews/frontend-takehome.md
+++ b/interviews/frontend-takehome.md
@@ -1,94 +1,72 @@
 # Frontend Takehome Grading
 
-Hi!
-Thanks for looking at our frontend takehome grading rubric!
-These are the scores by which our engineering team evaluate frontend takehome assignments.
-We _don't_ establish a hard minimum of score for any opening -- these scores are a general rubric, not a hard rule.
-
-## Why?
-
-We believe in openness and transparency in our engineering practices.
-There must be _some_ criteria by which we evaluate takehome submissions, and if candidates are meant to be taking them, we'd like them to be clear to everyone.
-
-We also welcome any feedback you have on these!
-
-## Takehome Assignment Specifications
-
-In our opinion, an ideal takehome assignment should:
-
-* Expect (and state) a maximum time spent as 2-3 hours
-* Explain clear, easy-to-understand instructions, including:
-    * Minimum requirements for a successful submission
-    * Areas of work we expect the candidate to focus on
-    * Areas of work we do not expect the candidate to focus on or tackle at all
-* Provide enough range of complexity for submissions to demonstrate excellence in implementation
-* Request a limited 'delighter' feature set, with multiple options suggested to match various skill sets
-
 ## Section Scores
 
 ### Solution Completion
 
 All requirements are met as outlined by the assignment's requirements.
 
-* 💖 4: Completely completed, including discoverable edge cases
-* 👍 3: Completed except for one or two minor edge cases
-* 👎 2: Missing a major feature or a several smaller features
-* 🛑 1: Missing major features or is generally not functional
+- 💖 4: Completely completed, including discoverable edge cases
+- 👍 3: Completed except for one or two minor edge cases
+- 👎 2: Missing a major feature or a several smaller features
+- 🛑 1: Missing major features or is generally not functional
 
 ### Solution Quality
 
 Application can be used smoothly and without visible bugs.
 
-* 💖 4: Works smoothly and delightfully without any bugs
-* 👍 3: Works well with little to no buggy behavior on edge cases
-* 👎 2: Moderate bug or two on a major feature, or major bugs on edge cases
-* 🛑 1: Significant buggy behavior
+- 💖 4: Works smoothly and delightfully without any bugs
+- 👍 3: Works well with little to no buggy behavior on edge cases
+- 👎 2: Moderate bug or two on a major feature, or major bugs on edge cases
+- 🛑 1: Significant buggy behavior
 
 ### Code Quality
 
 Code is generally well-organized and easy to understand.
 
-* 💖 4: Well-organized and understandable; clear names; no major [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) or [SRP](https://en.wikipedia.org/wiki/Single_responsibility_principle) violations
-* 👍 3: All but one or two pieces of 4
-* 👎 2: All but one or two pieces of 1
-* 🛑 1: Sloppy and difficult to reason with; poor naming; major [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and/or [SRP](https://en.wikipedia.org/wiki/Single_responsibility_principle) violations
+- 💖 4: Well-organized and understandable; clear names; no major [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) or [SRP](https://en.wikipedia.org/wiki/Single_responsibility_principle) violations
+- 👍 3: All but one or two pieces of 4
+- 👎 2: All but one or two pieces of 1
+- 🛑 1: Sloppy and difficult to reason with; poor naming; major [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and/or [SRP](https://en.wikipedia.org/wiki/Single_responsibility_principle) violations
 
 ### Frontend Knowledge
-Core HTML5 and framework (e.g. React) fundamentals. See [Frontend Specifics](#frontend-specifics) below.
 
-* 💖 4: Reasonable APIs choices; no major anti-patterns; consistent and logical syntax choices 
-* 👍 3: All but one or two pieces of 4
-* 👎 2: All but one or two pieces of 1
-* 🛑 1: Suboptimal API choices; common anti-patterns; inconsistent or misleading syntax choices
+Core HTML5 and framework (e.g. React) fundamentals.
+See [Frontend Specifics](#frontend-specifics) below.
+
+- 💖 4: Reasonable APIs choices; no major anti-patterns; consistent and logical syntax choices
+- 👍 3: All but one or two pieces of 4
+- 👎 2: All but one or two pieces of 1
+- 🛑 1: Suboptimal API choices; common anti-patterns; inconsistent or misleading syntax choices
 
 ### Delighters
 
 Non-core features encouraged for completion after the core features.
 
-* 💖 +2: One piece of delighter content completed fully and Solution Completion is 💖4
-* 👍 +1: One delighter completed with bugs, or completed well but Solution Completion is 👍3
-* 👎 0: No delighter content was completed, or Solution Completion is 🛑1 or 👎2
+- 💖 +2: One piece of delighter content completed fully and Solution Completion is 💖4
+- 👍 +1: One delighter completed with bugs, or completed well but Solution Completion is 👍3
+- 👎 0: No delighter content was completed, or Solution Completion is 🛑1 or 👎2
 
 ## Frontend Specifics
 
 ### What We Look For
 
-* Use of framework best practices, particularly when it showcases understanding of proper use.
-* Concise, readable code that uses declarative constructs (e.g. .map) reasonably
-* React and other UI frameworks:
-    * DOM: no unnecessary DOM manipulation (i.e. unless for 3rd party libraries)
-    * State: immutability, pure functions, and isolated side effects per the framework's preferences
+- Use of framework best practices, particularly when it showcases understanding of proper use.
+- Concise, readable code that uses declarative constructs (e.g. .map) reasonably
+- React and other UI frameworks:
+  - DOM: no unnecessary DOM manipulation (i.e. unless for 3rd party libraries)
+  - State: immutability, pure functions, and isolated side effects per the framework's preferences
 
 ### What We Ignore
 
-We don't penalize candidates for consistent style choices that don't demonstrate significant knowledge gaps, such as ones that could legitimately be preferable. 
+We don't penalize candidates for consistent style choices that don't demonstrate significant knowledge gaps, such as ones that could legitimately be preferable.
 
-* Nitpicks: we don't require completely optimal declarative or functional patterns
-* Performance: e.g. .forEach vs. for-const-of
-* Style: e.g. files and folder structures;  formatting/whitespace; grouping, naming, or sorting...
-* Syntax: e.g. `let` vs. `const`; traditional vs. arrow functions; import style...
+- Nitpicks: we don't require completely optimal declarative or functional patterns
+- Performance: e.g. .forEach vs. for-const-of
+- Style: e.g. files and folder structures; formatting/whitespace; grouping, naming, or sorting...
+- Syntax: e.g. `let` vs. `const`; traditional vs. arrow functions; import style...
 
 We don't have a preference for patterns or APIs the applicant wouldn't need to know:
 
-* CSS: naming principles such as [BEM](https://en.wikipedia.org/wiki/Single_responsibility_principle)
-* Style choices within frameworks; for example, within React, class components vs. function components _(not everyone has been taught hooks yet!)_
+- CSS: naming principles such as [BEM](https://en.wikipedia.org/wiki/Single_responsibility_principle)
+- Style choices within frameworks; for example, within React, class components vs. function components _(not everyone has been taught hooks yet!)_


### PR DESCRIPTION
Adds a shared `interviews/README.md` with the common FAQ-style explanations between backend & frontend takehome grading. Copies over the rubric we've been using for backend grading.

As discussed with @hoffm, we'll likely have a few action items after this intern hiring season:

* Look into consolidating the two rubrics to be more similar
* Create a separate "takehome-grading" repo or similar
* Switch our `internship-code-challenge` repo to be closed source when not in interview season _(heh)_