### PR TITLE
Competency Explorer: update README to include link to matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ Establishing a strong performance baseline at your level will further set you up
 
 The further you progress in your career the more time it will take to demonstrate proficiency in specific areas.
 Certain competencies include “established a track record of”. Generally it takes a minimum of 3-4 quarters to be able to repeat a certain set of expectations and demonstrate consistent proficiency.
+
+### Can I see these competencies in a matrix form?
+
+Yes! You can go the [GitHub Page](codecademy.github.io/engineering-competencies) to see the interactive matrix view. It pulls from this markdown file so it should always be up to date.

--- a/README.md
+++ b/README.md
@@ -235,4 +235,4 @@ Certain competencies include “established a track record of”. Generally it t
 
 ### Can I see these competencies in a matrix form?
 
-Yes! You can go the [GitHub Page](codecademy.github.io/engineering-competencies) to see the interactive matrix view. It pulls from this markdown file so it should always be up to date.
+Yes! You can go the [GitHub Page](https://codecademy.github.io/engineering-competencies) to see the interactive matrix view. It pulls from this markdown file so it should always be up to date.


### PR DESCRIPTION
## Overview
PR #26 added the GitHub page view for being able to drill into the competencies for Codecademy engineers; this PR exposes the page through a FAQ on the README.

## Testing Instructions
Verify that the link in the README takes you to the appropriate github page view.
