### PR TITLE
Update the Manager Engineering Competencies

### DIFF
--- a/managers.md
+++ b/managers.md
@@ -37,7 +37,7 @@ You are a frontline manager who is responsible for a functional area and leads a
 
 ## Senior Engineering Manager
 
-You are an experienced manager who manages up to two teams directly or
+You are an experienced manager who manages one large team or up to two teams directly or
 through managing a manager.
 
 ### Management & Leadership

--- a/managers.md
+++ b/managers.md
@@ -5,7 +5,7 @@ Engineering Manager, Senior Engineering Manager, Director, and VP.
 
 ## Engineering Manager
 
-You are a frontline manager who is responsible for a functional area and leads a small team of up to six engineers.
+You are a frontline manager who is responsible for a functional area and leads a small to medium sized team.
 
 ### Management & Leadership
 

--- a/managers.md
+++ b/managers.md
@@ -9,55 +9,35 @@ You are a frontline manager who is responsible for a functional area and leads a
 
 ### Management & Leadership
 
-- You work with your team to establish, contribute, and drive best practices.
-- You identify areas that could be improved and partner with others on the engineering team to improve processes within engineering.
-- You are a role model and celebrate people on your team and the broader engineering team who are acting as role models themselves.
-- You set clear goals and expectations.
-- You provide continuous feedback on whether goals and expectations are being met and how engineers can improve.
-- You are focused on identifying and supporting ways to help the members on your team learn and grow through clear career development goals and objectives.
-- You coach members of your team and help them grow and develop.
-- You work with the engineering leadership team, your teams, and corresponding stakeholders to set a successful strategy and vision for your functional area.
-
+- You manage a single team.
+- You manage & coach individual contributors (ICs). You put ICs up for promotion as appropriate.
+- You plan for team needs, through suggesting headcount (including levels & stack), proposing tools & integrations that support team goals, and identifying dependencies.
+- You own hiring on the team. You identify gaps in skills and be responsible for building a talented and diverse portfolio on the team.
+- You own overall retention strategy on the team.
 ### Software Engineering & Design
 
-- You hold your team to the software engineering and design standards we have set for individual contributors.
-- You provide an environment (process, tools, goals, sprints, etc) that allows individual contributors to do their best work.
-- When you contribute technically, you exemplify the standards we set for individual contributors.
+- You ensure the team has strong technical best practices. You provide the team with opportunities to enhance technical skills.
+- You are a technical and interpersonal role model. You help resolve technical issues and advise on technical decisions.
 
 ### Execution & Results
 
-- You have established a track record of effectively managing your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You help create organization and structure around large projects & problems that aren’t well defined, thereby setting your team up to successfully deliver on initiatives.
-- You have established a track record of investigating and vetting the reuse of existing components and services when approaching new projects and feature requests.
-- You can orchestrate and coordinate projects & solve problems that span across multiple teams.
-- You are responsible for working with stakeholders (PM, Design, DS, etc) to drive planning for your teams OKRs and goals.
-- You partner with stakeholders (PM, Design, DS, etc) to prioritize quarterly and sprint goals as well as allocate work accordingly and effectively.
-- You provide timely code reviews and are responsive to peer feedback on code reviews and learn from it.
+- You define processes (e.g. grooming, retro, team syncs, etc) for the team with cross-functional counterparts and the team directly.
+- You ensure all members of your team have the opportunity to demonstrate project ownership. You may opt to take project management on for high stakes or high urgency initiatives.
+- You shield the team from external changes (to the degree possible). You keep the team focused on the tasks explicitly assigned. You influence the decisions that are made regarding your team directly.
 
 ### Collaboration & Communication
 
-- You seek feedback on your own design & technical proposals while facilitating technical discussions on your team and make sure other engineers follow the same best practices.
-- You ask thoughtful questions and challenge assumptions to ensure you and your team are solving the right problems.
-- You listen attentively to team members’ ideas and concerns, consider their viewpoints, and ask clarifying questions that elicit clearer responses.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You help engineers on your team with the end-to-end delivery of their code from design, code, tests, monitoring/alerts, deployment and rollout.
-- You are a thoughtful verbal and written communicator, both within your team and across teams.
-- You share vision and perspective with your team and the broader engineering team as a whole.
-- You foster an inclusive team culture that supports constructive feedback and encourages diversity of thought.
-- You amplify all voices on the team to ensure all are heard.
+- You partner with relevant counterparts (e.g. Product, Design, Marketing, Curriculum, Data Science, etc…) to build team roadmaps, establish best practices.
+- You escalate challenges the team is facing to the larger engineering (or engineering leadership) team, and suggest solutions.
 
 ### Community & Citizenship
 
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs and providing constructive comments.
-- You fix out of date code, tests, scripts, runbooks, and documentation.
-- You are interview-trained and share the interview load for your team.
-- You fix broken processes and improve upon successful ones.
-- You cultivate blameless culture that focuses on fixing problems not pointing fingers.
-- You attend and contribute to conversations within our tech community (e.g. book club, lighting talks, blog posts)
+- You own the success of your entire team. You ensure the team is celebrated for successes and has opportunities to learn from failure. 
+- You start to own at least one engineering-wide initiative (e.g. tech community pillar, interviewing, revising competencies)
 
 ## Senior Engineering Manager
 
-You are an experienced manager who manages one large team or up to two teams directly or
+You are an experienced manager who manages up to two teams directly or
 through managing a manager.
 
 ### Management & Leadership
@@ -91,60 +71,37 @@ through managing a manager.
 
 ## Director
 
-You are a manager who is responsible for multiple functional areas, owns a budget, and leads a larger, cross-functional team.
+You are a manager who is responsible for the performance of a group of teams (organization)
+that share a particular focus (eg. product teams, platform teams, data science teams).
 
 ### Management & Leadership
 
-- You work with your teams to establish, contribute, and drive best practices.
-- You identify areas that could be improved and partner with others on the engineering team and managers on your team to improve processes within engineering.
-- You are a role model and celebrate people on your team and the broader engineering team who are acting as role models themselves.
-- You set clear goals and expectations and work with your managers to set clear goals and expectations within their teams.
-- You provide continuous feedback on whether goals and expectations are being met and how team members can improve.
-- You are focused on identifying and supporting ways to help the members on your team learn and grow through clear career development goals and objectives.
-- You coach members of your team and help them grow and develop.
-- You are able to and might manage multiple teams and managers.
-- You work with the engineering leadership team, your teams, and corresponding stakeholders to set a successful strategy and vision for your functional areas.
+- You manage all the teams in an Organization through the support and direction of the team managers.
+- You manage EMs (or ICs directly during a transition). You have multiple instances of successful promos, including ICs with a successful transition to EM or Staff Engineer.
+- You advocate for headcount and budgets to be allocated to the entire Organization, using feedback from EMs and Sr EMs as guidance. You understand the needs other Organizations have, and escalate or adjust if those needs will impede your Organization’s needs. You understand the strategy for the Company, and ensure your Organization is structured and capacity balanced to support it.
+- You scout and attract talent. You build relationships with potential candidates. You help in building candidate pipelines. You runs org wide hiring initiatives. You make key hire calls.
+- You provide a larger org view on retention and strongly influence decisions that can help in this regard.
 
 ### Software Engineering & Design
 
-- You hold your team to the software engineering and design standards we have set for individual contributors.
-- You provide an environment (process, tools, goals, sprints, etc) that allows managers and individual contributors to do their best work.
-- You contribute to technical decision making and exemplify the same standards we set for individual contributors.
-- You work with your teams to help set software engineering and design standards.
-- You facilitate adoption of your team's standards across the broader engineering team.
+- You build technical experts within the teams who can continue building out best practices (e.g. tech leads). You ensure these technical experts have opportunities to help build technical skills across the Organization your teams fit into.
+- You are a role model for interpersonal skills, execution and results. You focus on empowering ICs and managers to take on role modeling (technical & interpersonal), and share examples of that role modeling across teams. You ensure technical experts are brought into conversation within and external to the team, and establish them as a subject matter experts (SME) to the entire organization.
 
 ### Execution & Results
 
-- You have established a track record of effectively managing your time and know when to ask for help to unblock yourself. When blocked, you are resourceful and take initiative in finding other tasks to complete.
-- You help create organization and structure around large projects & problems that aren’t well defined, thereby setting your team up to successfully deliver on initiatives.
-- You identify when to delegate tasks appropriately to your managers and team.
-- You have established a track record of investigating and vetting the reuse of existing components and services when approaching new projects and feature requests.
-- You can orchestrate and coordinate projects & solve problems that span across multiple teams.
-- You are responsible for working with stakeholders (PM, Design, EMs, DS, etc) to drive planning for your teams OKRs and goals.
-- You partner with stakeholders (PM, Design, DS, etc) to prioritize quarterly and sprint goals as well as allocate work accordingly and effectively.
-- You lead multiple disparate teams and are able to effectively manage projects and initiatives across those functional areas.
-- You own the budget for your functional area and are responsible for expenses and hiring plans.
+- You delegate team process ownership to members of the teams, but align those processes to work well together. You understand the processes and owners of the processes. You share context across all engineering teams on processes, and help with rollouts of processes as needed.
+- You ensure each team has what they need to support the projects they are  responsible for. You connect individuals across teams or roles in order to keep projects running effectively. You step in only as it becomes clear something is off track, and step back when it is back on track.
+- You demonstrate strong change management skills that allow the team to directly impact the changes that are coming, with minimal trepidation about these changes. You coach change management within your teams, and build practices that reduce the fear of change within your teams. You empower teams to make decisions themselves that will affect their work, and advocate for that empowerment at the organizational level.
 
 ### Collaboration & Communication
 
-- You facilitate technical discussions on your team and make sure other managers and engineers follow the same best practices.
-- You ask thoughtful questions and challenge assumptions to ensure you and your team are solving the right problems.
-- You listen attentively to team members’ ideas and concerns, consider their viewpoints, and ask clarifying questions that elicit clearer responses.
-- You proactively communicate your progress and blockers to stakeholders (eg. PM, Design, Ops, etc.), your team, and manager and ensure timely project delivery.
-- You may help engineers on your team with the end-to-end delivery of their code from design, code, tests, monitoring/alerts, deployment and rollout.
-- You are a thoughtful verbal and written communicator, both within your team and across teams.
-- You share vision and perspective with your team and the broader engineering team as a whole.
-- You foster an inclusive team culture that supports constructive feedback and encourages diversity of thought.
-- You amplify all voices on the team to ensure all are heard.
+- You partner with other director level counterparts, in addition to building relationships with counterparts on teams. You have a track record of this partnership across multiple roles. You set direction and vision for the teams in collaboration with counterparts. You ensure partnerships within teams are collaborating well. You define direction and vision for the Organization your teams fit into, and shape direction and vision at the company level.
+- You escalate challenges the team is facing to the larger engineering (or engineering leadership) team and empower managers on your team to take on ownership of these challenges across the organization (or own yourself if need be). You partner with counterparts to drive company-wide initiatives forward.
 
 ### Community & Citizenship
 
-- You do things that benefit your peers and community such as providing feedback on product features, filing detailed bugs and providing constructive comments.
-- You fix out of date code, tests, scripts, runbooks, and documentation.
-- You are interview-trained and share the interview load for your team.
-- You fix broken processes and improve upon successful ones.
-- You cultivate blameless culture that focuses on fixing problems not pointing fingers.
-- You are a leader within and contribute to our tech community (e.g. book club, lighting talks, blog posts).
+- You own the success of your teams, in addition to the entire engineering team. You celebrate wins that happen in any part of the organization, especially outside of the teams you work with day-to-day.
+- You own or have owned multiple engineering-wide initiatives. You sponsor and support new initiatives proposed by other managers.
 
 ## VP
 


### PR DESCRIPTION
This is the successor to https://github.com/Codecademy/engineering-competencies/pull/71; however, I removed the [revert](https://github.com/Codecademy/engineering-competencies/pull/71/commits/c2093af4aea8b48ef79bbc004edec9cbcd60cb88) to the EM and Director competencies that was put it due to the proximity of a performance review.